### PR TITLE
fix(async-storage): Add support for `workUnitAsyncStorage`

### DIFF
--- a/src/utils/async-storages.ts
+++ b/src/utils/async-storages.ts
@@ -3,11 +3,20 @@ import type { AsyncLocalStorage } from 'node:async_hooks';
 import { safeImport } from '@/utils/dynamic-import';
 
 export function getExpectedRequestStore(callingExpression: string) {
-  const workUnitStoreModule = safeImport<{
-    getExpectedRequestStore: any;
-  }>('next/dist/server/app-render/work-unit-async-storage.external');
+  const workUnitStoreModule = safeImport<
+    | {
+        getExpectedRequestStore: any;
+      }
+    | {
+        workUnitAsyncStorage: AsyncLocalStorage<any>;
+      }
+  >('next/dist/server/app-render/work-unit-async-storage.external');
   if (workUnitStoreModule) {
-    return workUnitStoreModule.getExpectedRequestStore(callingExpression);
+    if ('getExpectedRequestStore' in workUnitStoreModule) {
+      return workUnitStoreModule.getExpectedRequestStore();
+    }
+
+    return workUnitStoreModule.workUnitAsyncStorage.getStore();
   }
 
   const requestStoreModule = safeImport<{

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,12 +1,10 @@
 import { defineConfig } from 'tsup';
 
-export default defineConfig([
-  {
-    clean: true,
-    dts: true,
-    entry: ['src/*.ts', 'src/*.tsx', '!src/*.test.ts', '!src/*.test.tsx'],
-    format: ['cjs', 'esm'],
-    target: 'esnext',
-    outDir: 'dist',
-  },
-]);
+export default defineConfig((options) => ({
+  clean: !options.watch,
+  dts: true,
+  entry: ['src/*.ts', 'src/*.tsx', '!src/*.test.ts', '!src/*.test.tsx'],
+  format: ['cjs', 'esm'],
+  target: 'esnext',
+  outDir: 'dist',
+}));


### PR DESCRIPTION
The internal API for accessing the request store in Next.js has changed in recent canary versions. This commit updates the logic to support both the `getExpectedRequestStore` function and the new `workUnitAsyncStorage` property.

Closes #75